### PR TITLE
Fix whitespace bug in parseBRCode

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,6 @@
 export function parseBRCode(brCode: string): { raw: string } {
-    return { raw: brCode.trim() };
-  }
+  // Remove all whitespace characters from the provided BR Code
+  const sanitized = brCode.replace(/\s+/g, '');
+  return { raw: sanitized };
+}
   

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -2,8 +2,8 @@ import { describe, it, expect } from 'vitest';
 import { parseBRCode } from '../src';
 
 describe('parseBRCode', () => {
-  it('should return raw code', () => {
-    const result = parseBRCode(' 000201 ');
+  it('should remove surrounding and internal whitespace', () => {
+    const result = parseBRCode(' 0002 01\n');
     expect(result).toEqual({ raw: '000201' });
   });
 });


### PR DESCRIPTION
## Summary
- clean up whitespace in `parseBRCode`
- test removing internal whitespace

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685069acae0883288c4855077e9174c5