### PR TITLE
Add newline, tab, and no-whitespace tests

### DIFF
--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -6,4 +6,15 @@ describe('parseBRCode', () => {
     const result = parseBRCode(' 0002 01\n');
     expect(result).toEqual({ raw: '000201' });
   });
+
+  it('should handle newline and tab characters', () => {
+    const result = parseBRCode('\n000201\t');
+    expect(result).toEqual({ raw: '000201' });
+  });
+
+  it('should return the same string when there is no whitespace', () => {
+    const input = '000201';
+    const result = parseBRCode(input);
+    expect(result).toEqual({ raw: input });
+  });
 });


### PR DESCRIPTION
## Summary
- expand test coverage for parseBRCode
- cover newline and tab characters
- ensure identical output when no whitespace is present

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685072f6178883288a96621d80fbb07e