### PR TITLE
Implement TLV parsing

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,4 +3,20 @@ export function parseBRCode(brCode: string): { raw: string } {
   const sanitized = brCode.replace(/\s+/g, '');
   return { raw: sanitized };
 }
-  
+
+export function parseTLV(emv: string): Record<string, string> {
+  const result: Record<string, string> = {};
+  let index = 0;
+
+  while (index < emv.length) {
+    const tag = emv.substring(index, index + 2);
+    const length = parseInt(emv.substring(index + 2, index + 4), 10);
+    const valueStart = index + 4;
+    const valueEnd = valueStart + length;
+
+    result[tag] = emv.substring(valueStart, valueEnd);
+    index = valueEnd;
+  }
+
+  return result;
+}

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { parseBRCode } from '../src';
+import { parseBRCode, parseTLV } from '../src';
 
 describe('parseBRCode', () => {
   it('should remove surrounding and internal whitespace', () => {
@@ -16,5 +16,18 @@ describe('parseBRCode', () => {
   it('should return the same string when there is no whitespace', () => {
     const result = parseBRCode('000201');
     expect(result).toEqual({ raw: '000201' });
+  });
+});
+
+describe('parseTLV', () => {
+  it('should parse a simple TLV string', () => {
+    const result = parseTLV('000201');
+    expect(result).toEqual({ '00': '01' });
+  });
+
+  it('should parse nested merchant information', () => {
+    const tlv = parseTLV('00020126080004ABCD');
+    const merchantInfo = parseTLV(tlv['26']);
+    expect(merchantInfo).toEqual({ '00': 'ABCD' });
   });
 });


### PR DESCRIPTION
## Summary
- support EMV TLV parsing via `parseTLV`
- test new parser with simple and nested cases

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685075bc4e608328aa13c3cddfb87dc3