### PR TITLE
Add BR Code parsing logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,12 @@ npm install pix-brcode-parser
 ```typescript
 import { parseBRCode } from 'pix-brcode-parser';
 
-const resultado = parseBRCode(' 000201 ');
-console.log(resultado);
-// => { raw: '000201' }
+const code =
+  '00020101021226370014BR.GOV.BCB.PIX0115abc@example.com5204000053039865406123.455802BR5907MATHEUS6008SAOPAULO61081234567862100506abc1236304ABCD';
+
+const resultado = parseBRCode(code);
+console.log(resultado.type); // "DYNAMIC"
+console.log(resultado.pixKey); // "abc@example.com"
 ```
 
 ## Desenvolvimento

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,75 @@
-export function parseBRCode(brCode: string): { raw: string } {
-  // Remove all whitespace characters from the provided BR Code
-  const sanitized = brCode.replace(/\s+/g, '');
-  return { raw: sanitized };
+export interface TLVData {
+  [tag: string]: string;
 }
-  
+
+export function parseTLV(data: string): TLVData {
+  const result: TLVData = {};
+  let i = 0;
+  while (i < data.length) {
+    const tag = data.slice(i, i + 2);
+    const length = parseInt(data.slice(i + 2, i + 4), 10);
+    const value = data.slice(i + 4, i + 4 + length);
+    result[tag] = value;
+    i += 4 + length;
+  }
+  return result;
+}
+
+export interface ParsedBRCode {
+  raw: string;
+  type: 'STATIC' | 'DYNAMIC';
+  payloadFormatIndicator?: string;
+  merchantCategoryCode?: string;
+  transactionCurrency?: string;
+  transactionAmount?: string;
+  countryCode?: string;
+  merchantName?: string;
+  merchantCity?: string;
+  postalCode?: string;
+  txid?: string;
+  pixKey?: string;
+  infoAdicional?: string;
+}
+
+export function parseBRCode(brCode: string): ParsedBRCode {
+  const sanitized = brCode.replace(/\s+/g, '');
+  const tlv = parseTLV(sanitized);
+
+  const type: 'STATIC' | 'DYNAMIC' = tlv['01'] === '12' ? 'DYNAMIC' : 'STATIC';
+
+  const additional = tlv['62'] ? parseTLV(tlv['62']) : {};
+
+  let pixKey: string | undefined;
+  let infoAdicional: string | undefined;
+
+  for (let i = 26; i <= 51; i++) {
+    const tag = String(i).padStart(2, '0');
+    const value = tlv[tag];
+    if (value) {
+      const sub = parseTLV(value);
+      if (sub['00'] && sub['00'].toUpperCase() === 'BR.GOV.BCB.PIX') {
+        pixKey = sub['01'];
+        if (sub['02']) {
+          infoAdicional = sub['02'];
+        }
+        break;
+      }
+    }
+  }
+
+  return {
+    raw: sanitized,
+    type,
+    payloadFormatIndicator: tlv['00'],
+    merchantCategoryCode: tlv['52'],
+    transactionCurrency: tlv['53'],
+    transactionAmount: tlv['54'],
+    countryCode: tlv['58'],
+    merchantName: tlv['59'],
+    merchantCity: tlv['60'],
+    postalCode: tlv['61'],
+    txid: additional['05'],
+    pixKey,
+    infoAdicional,
+  };
+}

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -2,19 +2,33 @@ import { describe, it, expect } from 'vitest';
 import { parseBRCode } from '../src';
 
 describe('parseBRCode', () => {
-  it('should remove surrounding and internal whitespace', () => {
-    const result = parseBRCode(' 0002 01\n');
-    expect(result).toEqual({ raw: '000201' });
+  const dynamicCode = '00020101021226370014BR.GOV.BCB.PIX0115abc@example.com5204000053039865406123.455802BR5907MATHEUS6008SAOPAULO61081234567862100506abc1236304ABCD';
+  const staticCode = '00020101021126370014BR.GOV.BCB.PIX0115abc@example.com5204000053039865406123.455802BR5907MATHEUS6008SAOPAULO61081234567862100506abc1236304ABCD';
+
+  it('should remove surrounding whitespace and parse fields', () => {
+    const result = parseBRCode(`  ${dynamicCode}  `);
+    expect(result.raw).toBe(dynamicCode);
+    expect(result.type).toBe('DYNAMIC');
+    expect(result.payloadFormatIndicator).toBe('01');
+    expect(result.merchantCategoryCode).toBe('0000');
+    expect(result.transactionCurrency).toBe('986');
+    expect(result.transactionAmount).toBe('123.45');
+    expect(result.countryCode).toBe('BR');
+    expect(result.merchantName).toBe('MATHEUS');
+    expect(result.merchantCity).toBe('SAOPAULO');
+    expect(result.postalCode).toBe('12345678');
+    expect(result.txid).toBe('abc123');
+    expect(result.pixKey).toBe('abc@example.com');
   });
 
+  it('should detect static codes', () => {
+    const result = parseBRCode(staticCode);
+    expect(result.type).toBe('STATIC');
+  });
 
   it('should handle newlines and tabs', () => {
-    const result = parseBRCode('\n000201\t');
-    expect(result).toEqual({ raw: '000201' });
-  });
-
-  it('should return the same string when there is no whitespace', () => {
-    const result = parseBRCode('000201');
-    expect(result).toEqual({ raw: '000201' });
+    const spaced = `\n${dynamicCode}\t`;
+    const result = parseBRCode(spaced);
+    expect(result.raw).toBe(dynamicCode);
   });
 });


### PR DESCRIPTION
## Summary
- implement TLV and BR Code parsing
- expand tests for new parsing functionality
- update README with basic example

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6850774984f483289eda78c432de88d4