### PR TITLE
Add BRCodeData type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -15,23 +15,23 @@ export function parseTLV(data: string): TLVData {
   return result;
 }
 
-export interface ParsedBRCode {
-  raw: string;
+export interface BRCodeData {
   type: 'STATIC' | 'DYNAMIC';
-  payloadFormatIndicator?: string;
+  payloadFormatIndicator: string;
   merchantCategoryCode?: string;
   transactionCurrency?: string;
-  transactionAmount?: string;
+  transactionAmount?: number;
   countryCode?: string;
   merchantName?: string;
   merchantCity?: string;
   postalCode?: string;
-  txid?: string;
   pixKey?: string;
   infoAdicional?: string;
+  txid?: string;
+  raw: string;
 }
 
-export function parseBRCode(brCode: string): ParsedBRCode {
+export function parseBRCode(brCode: string): BRCodeData {
   const sanitized = brCode.replace(/\s+/g, '');
   const tlv = parseTLV(sanitized);
 
@@ -60,10 +60,10 @@ export function parseBRCode(brCode: string): ParsedBRCode {
   return {
     raw: sanitized,
     type,
-    payloadFormatIndicator: tlv['00'],
+    payloadFormatIndicator: tlv['00'] || '',
     merchantCategoryCode: tlv['52'],
     transactionCurrency: tlv['53'],
-    transactionAmount: tlv['54'],
+    transactionAmount: tlv['54'] ? parseFloat(tlv['54']) : undefined,
     countryCode: tlv['58'],
     merchantName: tlv['59'],
     merchantCity: tlv['60'],

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -12,7 +12,7 @@ describe('parseBRCode', () => {
     expect(result.payloadFormatIndicator).toBe('01');
     expect(result.merchantCategoryCode).toBe('0000');
     expect(result.transactionCurrency).toBe('986');
-    expect(result.transactionAmount).toBe('123.45');
+    expect(result.transactionAmount).toBe(123.45);
     expect(result.countryCode).toBe('BR');
     expect(result.merchantName).toBe('MATHEUS');
     expect(result.merchantCity).toBe('SAOPAULO');


### PR DESCRIPTION
## Summary
- add new `BRCodeData` interface and return it from `parseBRCode`
- parse transaction amounts as numbers
- update tests for numeric amount

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68507961a06483288322c906fc97ae2b