### PR TITLE
Add test for incomplete TLV

### DIFF
--- a/test/parseTLV.test.ts
+++ b/test/parseTLV.test.ts
@@ -20,4 +20,10 @@ describe('parseTLV', () => {
   it('throws when tag or length is not numeric', () => {
     expect(() => parseTLV('AA0201')).toThrowError('Campo fora do padrão')
   })
+
+  it('throws when tag or length field is incomplete', () => {
+    expect(() => parseTLV('00')).toThrowError(
+      'Invalid TLV format: incomplete tag or length',
+    )
+  })
 })


### PR DESCRIPTION
## Summary
- add a test checking for incomplete tag/length handling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6850c247808483289dd315467ae492e4