### PR TITLE
Add test for empty payload indicator

### DIFF
--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -55,6 +55,12 @@ describe('parseBRCode', () => {
     expect(() => parseBRCode(codeWithout00)).toThrowError('Tag obrigatória ausente: 00');
   });
 
+  it('should treat empty tag 00 as missing', () => {
+    const codeWithEmpty00 =
+      '000001021226370014BR.GOV.BCB.PIX0115abc@example.com5204000053039865406123.455802BR5907MATHEUS6008SAOPAULO61081234567862100506abc1236304A537';
+    expect(() => parseBRCode(codeWithEmpty00)).toThrowError('Tag obrigatória ausente: 00');
+  });
+
   it('should throw when mandatory tag 26 is missing', () => {
     const codeWithout26 =
       '0002010102125204000053039865406123.455802BR5907MATHEUS6008SAOPAULO61081234567862100506abc12363046BDE';


### PR DESCRIPTION
## Summary
- add a regression test for codes with empty payload indicator

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6850c3fec5cc8328ae8a07601f802fb4