### PR TITLE
Add infoAdicional unit test

### DIFF
--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -111,4 +111,13 @@ describe('parseBRCode', () => {
     expect(result.txid).toBeUndefined();
     expect(result.pixKey).toBe('abc@example.com');
   });
+
+  it('should extract infoAdicional when subfield 02 is present', () => {
+    const body =
+      '00020101021226450014BR.GOV.BCB.PIX0115abc@example.com0204test5204000053039865406123.455802BR5907MATHEUS6008SAOPAULO61081234567862100506abc123';
+    const code = body + '6304' + computeCRC16(body + '6304');
+    const result = parseBRCode(code);
+    expect(result.infoAdicional).toBe('test');
+    expect(result.pixKey).toBe('abc@example.com');
+  });
 });


### PR DESCRIPTION
## Summary
- add a new unit test covering extraction of infoAdicional from the BR Code

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6850c483cff483288d31f6551e2c41ea