### PR TITLE
Add test for empty payloadFormatIndicator

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -66,7 +66,7 @@ export function parseBRCode(brCode: string): BRCodeData {
   const sanitized = brCode.replace(/\s+/g, '');
   const tlv = parseTLV(sanitized);
 
-  if (!tlv['00']) {
+  if (!Object.prototype.hasOwnProperty.call(tlv, '00')) {
     throw new Error('Tag obrigatória ausente: 00');
   }
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -55,10 +55,11 @@ describe('parseBRCode', () => {
     expect(() => parseBRCode(codeWithout00)).toThrowError('Tag obrigatória ausente: 00');
   });
 
-  it('should treat empty tag 00 as missing', () => {
+  it('should handle empty tag 00 and set empty payloadFormatIndicator', () => {
     const codeWithEmpty00 =
       '000001021226370014BR.GOV.BCB.PIX0115abc@example.com5204000053039865406123.455802BR5907MATHEUS6008SAOPAULO61081234567862100506abc1236304A537';
-    expect(() => parseBRCode(codeWithEmpty00)).toThrowError('Tag obrigatória ausente: 00');
+    const result = parseBRCode(codeWithEmpty00);
+    expect(result.payloadFormatIndicator).toBe('');
   });
 
   it('should throw when mandatory tag 26 is missing', () => {


### PR DESCRIPTION
## Summary
- allow TLV tag 00 to be empty without throwing an error
- cover empty `payloadFormatIndicator` value in tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6850c51675988328b2e449fc6b63f97a